### PR TITLE
Make an exception with _3d import on QGS101 and QGS102

### DIFF
--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -49,7 +49,11 @@ def _test_qgis_module(module: Optional[str]) -> Optional[str]:
     if len(modules) < 2:
         return None
 
-    if modules[0] in ("qgs", "qgis") and modules[1].startswith("_"):
+    if (
+        modules[0] in ("qgs", "qgis")
+        and modules[1].startswith("_")
+        and modules[1] != "_3d"
+    ):
         modules[1] = modules[1][1:]
         return ".".join(modules)
 

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -34,6 +34,11 @@ def test_QGS101_pass():
     assert ret == set()
 
 
+def test_QGS101_pass_with_3d_exception():
+    ret = _results("from qgis._3d import *")
+    assert ret == set()
+
+
 def test_QGS101():
     ret = _results("from qgs._core import QgsMapLayer, QgsVectorLayer")
     ret = ret.union(_results("from qgis._core import QgsApplication"))


### PR DESCRIPTION
Should be merged after #10.

Usually QGS101 or QGS102 is thrown when importing _ prefixed modules.
_3d is currently an exception to this rule, so we should not throw an
error when importing it. Importing just 3d would throw and SyntaxError
because 3d is not a valid package name because of the leading digit.
_3d is the only way to use the 3d module.

Resolves: #9 