### PR TITLE
Add QGS107: don't import iface, instead pass it as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Just call `flake8 .` in your package or `flake your.py`.
 * `QGS102`: Don't use imports from qgis protected members ([example](#QGS102))
 * `QGS103`: Don't use from-imports from PyQt directly ([example](#QGS103))
 * `QGS104`: Don't use imports from PyQt directly ([example](#QGS104))
-* `QGS105`: Don't pass QgisInterface as an argument ([example](#QGS105))
+* `QGS105`: Don't pass QgisInterface as an argument ([example](#QGS105)). If you want to use this rule, disable rule `QGS107`.
 * `QGS106`: Don't import gdal directly, import if from osgeo package ([example](#QGS106))
+* `QGS107`: Don't import QgisInterface instance (iface). Instead pass it as an argument ([example](#QGS107)). If you want to use this rule, disable rule `QGS105`.
 
 
 
@@ -43,9 +44,14 @@ To do that, use the standard Flake8 configuration. For example, within the `setu
 
 ```python
 [flake8]
-ignore = QGS101, QGS102
+ignore = QGS101, QGS107
 ```
 
+## Rule exclusive choices
+For QgisInterface, activate only `QGS105` OR `QGS107`, do not enable both as they cancel each other's out. If you want to use both approaches mixed, simply ignore both rules.
+Both ways of getting iface are valid, but there might be valid reason to chooce which one to use.
+* `QGS105`: it is much easier to import QgisInterface and it's easier to [mock](https://github.com/GispoCoding/pytest-qgis#hooks) it as well when writing tests. This approach is not however documented properly, so the API might change at some point to exclude this.
+* `QGS107`: this is the documented way of getting QgisInterface in plugins. However it requires writing more code.
 
 ## Examples
 
@@ -121,4 +127,18 @@ import ogr
 
 # Good
 from osgeo import gdal
+```
+
+### QGS107
+
+```python
+# Bad: iface imported
+from qgis.utils import iface
+
+def some_function(somearg):
+# do something with iface
+
+# Good: iface passed as argument
+def some_function(somearg, iface):
+    # do something with iface
 ```

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -6,6 +6,7 @@ from typing import Set
 # First party modules
 # First party
 from flake8_qgis import Plugin
+from flake8_qgis.flake8_qgis import QGS105, QGS107
 
 """Tests for `flake8_qgis` package."""
 
@@ -110,10 +111,7 @@ def some_function(somearg, iface):
     pass
         """
     )
-    assert ret == {
-        "2:0 QGS105 Do not pass iface (QgisInterface) as an argument, instead import "
-        "it: 'from qgis.utils import iface'"
-    }
+    assert ret == {"2:0 " + QGS105}
 
 
 def test_QGS105_typed():
@@ -123,10 +121,7 @@ def some_function(somearg, interface: QgisInterface):
     pass
         """
     )
-    assert ret == {
-        "2:0 QGS105 Do not pass iface (QgisInterface) as an argument, instead import "
-        "it: 'from qgis.utils import iface'"
-    }
+    assert ret == {"2:0 " + QGS105}
 
 
 def test_QGS105_method():
@@ -137,10 +132,7 @@ class SomeClass:
         pass
         """
     )
-    assert ret == {
-        "3:4 QGS105 Do not pass iface (QgisInterface) as an argument, instead import "
-        "it: 'from qgis.utils import iface'"
-    }
+    assert ret == {"3:4 " + QGS105}
 
 
 def test_QGS105_static_method():
@@ -153,10 +145,7 @@ class SomeClass:
         """
     )
     assert len(ret) == 1
-    assert list(ret)[0].endswith(
-        "QGS105 Do not pass iface (QgisInterface) as an argument, instead import "
-        "it: 'from qgis.utils import iface'"
-    )
+    assert list(ret)[0].endswith(QGS105)
 
 
 def test_QGS106_pass():
@@ -172,3 +161,8 @@ def test_QGS106():
         "1:0 QGS106 Use 'from osgeo import gdal' instead of 'import gdal'",
         "1:0 QGS106 Use 'from osgeo import ogr' instead of 'import ogr'",
     }
+
+
+def test_QGS107():
+    ret = _results("from qgis.utils import iface")
+    assert ret == {"1:0 " + QGS107}


### PR DESCRIPTION
This PR adds another rule QGS107:  "Don't import QgisInterface instance (iface). Instead pass it as an argument" alongside with QGS105:  "Don't pass QgisInterface as an argument". These rules cancel each other's out and the user must choose which approach to use.

Fixes #8.