### PR TITLE
Add test for QGS102 _3d exception

### DIFF
--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -38,9 +38,11 @@ def test_QGS101_pass_with_3d_exception():
     ret = _results("from qgis._3d import *")
     assert ret == set()
 
+
 def test_QGS102_pass_with_3d_exception():
     ret = _results("import qgis._3d")
     assert ret == set()
+
 
 def test_QGS101():
     ret = _results("from qgs._core import QgsMapLayer, QgsVectorLayer")

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -38,6 +38,9 @@ def test_QGS101_pass_with_3d_exception():
     ret = _results("from qgis._3d import *")
     assert ret == set()
 
+def test_QGS102_pass_with_3d_exception():
+    ret = _results("import qgis._3d")
+    assert ret == set()
 
 def test_QGS101():
     ret = _results("from qgs._core import QgsMapLayer, QgsVectorLayer")


### PR DESCRIPTION
There were no test for testing the _3d import exception for rule QGS102

```python
# Should be allowed
import qgis._3d
```
