### PR TITLE
add "long-term" enums to QGS403 rule 

### DIFF
--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -595,10 +595,17 @@ def _get_qgs403(node: ast.Attribute) -> list["FlakeError"]:
         and isinstance(node.parent, ast.Attribute)
         and (node.value.id, node.parent.attr) in DEPRECATED_RENAMED_ENUMS
     ):
+        new_enum_name, new_member_name = DEPRECATED_RENAMED_ENUMS[
+            (node.value.id, node.parent.attr)
+        ]
+        if node.attr == new_enum_name and node.parent.attr == new_member_name:
+            return []
+
         new = ".".join(
             [
                 node.value.id,
-                *DEPRECATED_RENAMED_ENUMS[(node.value.id, node.parent.attr)],
+                new_enum_name,
+                new_member_name,
             ]
         )
         old = ".".join([node.value.id, node.attr, node.parent.attr])

--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -159,10 +159,125 @@ QMETATYPE_MAPPING = {
 }
 
 DEPRECATED_RENAMED_ENUMS = {
+    # Mouse Button Changes
+    ("Qt", "LeftButton"): ("MouseButton", "LeftButton"),
+    ("Qt", "RightButton"): ("MouseButton", "RightButton"),
     ("Qt", "MidButton"): ("MouseButton", "MiddleButton"),
+    ("Qt", "BackButton"): ("MouseButton", "BackButton"),
+    ("Qt", "ForwardButton"): ("MouseButton", "ForwardButton"),
+    ("Qt", "TaskButton"): ("MouseButton", "TaskButton"),
+    ("Qt", "ExtraButton24"): ("MouseButton", "ExtraButton24"),
+    # Keyboard Modifier Changes
+    ("Qt", "NoModifier"): ("KeyboardModifier", "NoModifier"),
+    ("Qt", "ShiftModifier"): ("KeyboardModifier", "ShiftModifier"),
+    ("Qt", "ControlModifier"): ("KeyboardModifier", "ControlModifier"),
+    ("Qt", "AltModifier"): ("KeyboardModifier", "AltModifier"),
+    ("Qt", "MetaModifier"): ("KeyboardModifier", "MetaModifier"),
+    # Orientation Changes
+    ("Qt", "Horizontal"): ("Orientation", "Horizontal"),
+    ("Qt", "Vertical"): ("Orientation", "Vertical"),
+    # Scroll Bar Policy
+    ("Qt", "ScrollBarAsNeeded"): ("ScrollBarPolicy", "ScrollBarAsNeeded"),
+    ("Qt", "ScrollBarAlwaysOff"): ("ScrollBarPolicy", "ScrollBarAlwaysOff"),
+    ("Qt", "ScrollBarAlwaysOn"): ("ScrollBarPolicy", "ScrollBarAlwaysOn"),
+    # Sort Order Changes
+    ("Qt", "AscendingOrder"): ("SortOrder", "AscendingOrder"),
+    ("Qt", "DescendingOrder"): ("SortOrder", "DescendingOrder"),
+    # Case Sensitivity Changes
+    ("Qt", "CaseSensitive"): ("CaseSensitivity", "CaseSensitive"),
+    ("Qt", "CaseInsensitive"): ("CaseSensitivity", "CaseInsensitive"),
+    # Focus Policy Changes
+    ("Qt", "NoFocus"): ("FocusPolicy", "NoFocus"),
+    ("Qt", "TabFocus"): ("FocusPolicy", "TabFocus"),
+    ("Qt", "ClickFocus"): ("FocusPolicy", "ClickFocus"),
+    ("Qt", "StrongFocus"): ("FocusPolicy", "StrongFocus"),
+    ("Qt", "WheelFocus"): ("FocusPolicy", "WheelFocus"),
+    # ItemDataRole Changes
+    ("Qt", "DisplayRole"): ("ItemDataRole", "DisplayRole"),
+    ("Qt", "DecorationRole"): ("ItemDataRole", "DecorationRole"),
+    ("Qt", "EditRole"): ("ItemDataRole", "EditRole"),
+    ("Qt", "ToolTipRole"): ("ItemDataRole", "ToolTipRole"),
+    ("Qt", "StatusTipRole"): ("ItemDataRole", "StatusTipRole"),
+    ("Qt", "WhatsThisRole"): ("ItemDataRole", "WhatsThisRole"),
     ("Qt", "TextColorRole"): ("ItemDataRole", "ForegroundRole"),
     ("Qt", "BackgroundColorRole"): ("ItemDataRole", "BackgroundRole"),
+    ("Qt", "FontRole"): ("ItemDataRole", "FontRole"),
+    ("Qt", "TextAlignmentRole"): ("ItemDataRole", "TextAlignmentRole"),
+    ("Qt", "CheckStateRole"): ("ItemDataRole", "CheckStateRole"),
+    # CheckState Changes
+    ("Qt", "Unchecked"): ("CheckState", "Unchecked"),
+    ("Qt", "PartiallyChecked"): ("CheckState", "PartiallyChecked"),
+    ("Qt", "Checked"): ("CheckState", "Checked"),
+    # Connection Type Changes
+    ("Qt", "AutoConnection"): ("ConnectionType", "AutoConnection"),
+    ("Qt", "DirectConnection"): ("ConnectionType", "DirectConnection"),
+    ("Qt", "QueuedConnection"): ("ConnectionType", "QueuedConnection"),
+    ("Qt", "BlockingQueuedConnection"): ("ConnectionType", "BlockingQueuedConnection"),
+    ("Qt", "UniqueConnection"): ("ConnectionType", "UniqueConnection"),
+    # TextFormat Changes
+    ("Qt", "PlainText"): ("TextFormat", "PlainText"),
+    ("Qt", "RichText"): ("TextFormat", "RichText"),
+    ("Qt", "AutoText"): ("TextFormat", "AutoText"),
+    # TextElideMode Changes
+    ("Qt", "ElideLeft"): ("TextElideMode", "ElideLeft"),
+    ("Qt", "ElideRight"): ("TextElideMode", "ElideRight"),
+    ("Qt", "ElideMiddle"): ("TextElideMode", "ElideMiddle"),
+    ("Qt", "ElideNone"): ("TextElideMode", "ElideNone"),
+    # AspectRatioMode Changes
+    ("Qt", "IgnoreAspectRatio"): ("AspectRatioMode", "IgnoreAspectRatio"),
+    ("Qt", "KeepAspectRatio"): ("AspectRatioMode", "KeepAspectRatio"),
+    ("Qt", "KeepAspectRatioByExpanding"): (
+        "AspectRatioMode",
+        "KeepAspectRatioByExpanding",
+    ),
+    # Dock Widget Area Changes
+    ("Qt", "RightDockWidgetArea"): ("DockWidgetArea", "RightDockWidgetArea"),
+    ("Qt", "LeftDockWidgetArea"): ("DockWidgetArea", "LeftDockWidgetArea"),
+    # QPainter Changes
     ("QPainter", "HighQualityAntialiasing"): ("RenderHint", "Antialiasing"),
+    # QAbstractItemView SelectionMode Changes
+    ("QAbstractItemView", "SingleSelection"): ("SelectionMode", "SingleSelection"),
+    ("QAbstractItemView", "MultiSelection"): ("SelectionMode", "MultiSelection"),
+    ("QAbstractItemView", "ExtendedSelection"): ("SelectionMode", "ExtendedSelection"),
+    ("QAbstractItemView", "ContiguousSelection"): (
+        "SelectionMode",
+        "ContiguousSelection",
+    ),
+    ("QAbstractItemView", "NoSelection"): ("SelectionMode", "NoSelection"),
+    # QAbstractItemView SelectionBehavior Changes
+    ("QAbstractItemView", "SelectItems"): ("SelectionBehavior", "SelectItems"),
+    ("QAbstractItemView", "SelectRows"): ("SelectionBehavior", "SelectRows"),
+    ("QAbstractItemView", "SelectColumns"): ("SelectionBehavior", "SelectColumns"),
+    # QDialogButtonBox ButtonRole Changes
+    ("QDialogButtonBox", "AcceptRole"): ("ButtonRole", "AcceptRole"),
+    ("QDialogButtonBox", "RejectRole"): ("ButtonRole", "RejectRole"),
+    ("QDialogButtonBox", "HelpRole"): ("ButtonRole", "HelpRole"),
+    ("QDialogButtonBox", "YesRole"): ("ButtonRole", "YesRole"),
+    ("QDialogButtonBox", "NoRole"): ("ButtonRole", "NoRole"),
+    ("QDialogButtonBox", "ApplyRole"): ("ButtonRole", "ApplyRole"),
+    ("QDialogButtonBox", "ResetRole"): ("ButtonRole", "ResetRole"),
+    # QMessageBox Icon Changes
+    ("QMessageBox", "NoIcon"): ("Icon", "NoIcon"),
+    ("QMessageBox", "Question"): ("Icon", "Question"),
+    ("QMessageBox", "Information"): ("Icon", "Information"),
+    ("QMessageBox", "Warning"): ("Icon", "Warning"),
+    ("QMessageBox", "Critical"): ("Icon", "Critical"),
+    # QComboBox InsertPolicy Changes
+    ("QComboBox", "NoInsert"): ("InsertPolicy", "NoInsert"),
+    ("QComboBox", "InsertAtTop"): ("InsertPolicy", "InsertAtTop"),
+    ("QComboBox", "InsertAtCurrent"): ("InsertPolicy", "InsertAtCurrent"),
+    ("QComboBox", "InsertAtBottom"): ("InsertPolicy", "InsertAtBottom"),
+    ("QComboBox", "InsertAfterCurrent"): ("InsertPolicy", "InsertAfterCurrent"),
+    ("QComboBox", "InsertBeforeCurrent"): ("InsertPolicy", "InsertBeforeCurrent"),
+    ("QComboBox", "InsertAlphabetically"): ("InsertPolicy", "InsertAlphabetically"),
+    # QSizePolicy Policy Changes
+    ("QSizePolicy", "Fixed"): ("Policy", "Fixed"),
+    ("QSizePolicy", "Minimum"): ("Policy", "Minimum"),
+    ("QSizePolicy", "Maximum"): ("Policy", "Maximum"),
+    ("QSizePolicy", "Preferred"): ("Policy", "Preferred"),
+    ("QSizePolicy", "MinimumExpanding"): ("Policy", "MinimumExpanding"),
+    ("QSizePolicy", "Expanding"): ("Policy", "Expanding"),
+    ("QSizePolicy", "Ignored"): ("Policy", "Ignored"),
 }
 
 QGIS_RETURN_METHODS_PATH = Path(__file__).with_name("qgis_return_methods.json")

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -365,6 +365,16 @@ def test_QGS403():
         "instead of 'Qt.MouseButton.MidButton'."
     }
 
+    ret = _results("area = Qt.RightDockWidgetArea")
+    assert ret == {
+        "1:7 QGS403 Enum has been changed in Qt6. Use "
+        "'Qt.DockWidgetArea.RightDockWidgetArea' instead of "
+        "'Qt.RightDockWidgetArea'."
+    }
+
+    ret = _results("area = Qt.DockWidgetArea.RightDockWidgetArea")
+    assert ret == set()
+
 
 def test_QGS404():
     expected_error = {


### PR DESCRIPTION
add Qt6 "long-term" enums to QGS403 rule and not only enums where the names changed

all added enums where checked in the QGIS python console using the code:

```

from qgis.PyQt.QtCore import Qt
from qgis.PyQt.QtGui import QPainter
from qgis.PyQt.QtWidgets import (
    QAbstractItemView,
    QComboBox,
    QDialogButtonBox,
    QMessageBox,
    QSizePolicy,
)

DEPRECATED_RENAMED_ENUMS = {
    # paste dict from code
}

# Map module names to actual objects
modules = {
    "Qt": Qt,
    "QPainter": QPainter,
    "QAbstractItemView": QAbstractItemView,
    "QDialogButtonBox": QDialogButtonBox,
    "QMessageBox": QMessageBox,
    "QComboBox": QComboBox,
    "QSizePolicy": QSizePolicy,
}

errors = []

for (old_module, old_name), (new_module, new_name) in DEPRECATED_RENAMED_ENUMS.items():
    try:
        # Get Qt5 style value
        old_module_obj = modules[old_module]
        old_value = getattr(old_module_obj, old_name)

        # Try Qt6 style (nested enum)
        try:
            new_module_obj = getattr(old_module_obj, new_module)
            new_value = getattr(new_module_obj, new_name)

            # Check if values match
            if old_value != new_value:
                errors.append(
                    f"VALUE MISMATCH: {old_module}.{old_name}={old_value} vs {old_module}.{new_module}.{new_name}={new_value}"
                )
        except AttributeError:
            # Qt6 style doesn't exist
            print(f"error with {new_module_obj}")
    except (KeyError, AttributeError) as e:
        errors.append(f"ERROR: {old_module}.{old_name} | {str(e)}")

if errors:
    print("ENUM COMPATIBILITY ERRORS:")
    print("=" * 70)
    for error in errors:
        print(error)
else:
    print("sucsses")

```

## AI Usage: 
the added enums where generated by claude and tested using the code above (generated by claude and tweeked by hand)