### PR TITLE
Add rule QGS111

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Rule | Description
 [QGS108](#QGS108) | Use QgsProcessing.TEMPORARY_OUTPUT instead of "TEMPORARY_OUTPUT"
 [QGS109](#QGS109) | Use QgsProcessing.TEMPORARY_OUTPUT instead of misspelled "TEMPORARY_OUTPUT"
 [QGS110](#QGS110) | Use is_child_algorithm=True when running other algorithms in the plugin
+[QGS111](#QGS111) | Avoid importing processing directly, import it from qgis package
 [QGS201](#QGS201) | Check return values from a probable PyQgs method call
 [QGS202](#QGS202) | Check return values from a possible PyQgs method call
 [QGS401](#QGS401) | Use 'QApplication.instance()' instead of 'qApp'

--- a/README.md
+++ b/README.md
@@ -262,6 +262,22 @@ processing.run("native:buffer", {"INPUT": layer})
 processing.run("native:buffer", {"INPUT": layer}, is_child_algorithm=True)
 ```
 
+### QGS111
+Avoid importing processing directly, import it from qgis package
+
+#### Why is this bad?
+Although it works sometimes, it is not the recommended way to use the processing module.
+
+#### Example
+
+```python
+# Bad
+import processing
+
+# Good
+from qgis import processing
+```
+
 ### QGS201
 Check return values from a probable PyQgs method call.
 

--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -35,6 +35,7 @@ QGS109 = "QGS109 Replace '{old}' with QgsProcessing.TEMPORARY_OUTPUT"
 QGS110 = (
     "QGS110 Use is_child_algorithm=True when running other algorithms in the plugin"
 )
+QGS111 = "QGS111 Use 'from qgis import processing' instead of 'import processing'"
 
 # Return value rules
 QGS201 = (
@@ -474,6 +475,14 @@ def _get_qgs110(node: Call) -> list["FlakeError"]:
     return []
 
 
+def _get_qgs111(node: ast.Import) -> list["FlakeError"]:
+    errors: list[FlakeError] = []
+    for alias in node.names:
+        if alias.name == "processing":
+            errors.append((node.lineno, node.col_offset, QGS111))
+    return errors
+
+
 def _get_qgs201_and_qgs202(
     node: ast.Call, imported_names: set[str]
 ) -> list["FlakeError"]:
@@ -838,6 +847,7 @@ class Visitor(ast.NodeVisitor):
         self.errors += _get_qgs106(node)
         self.errors += _get_qgs406_import(node)
         self.errors += _get_qgs408_import(node)
+        self.errors += _get_qgs111(node)
 
     def visit_FunctionDef(self, node: FunctionDef) -> None:
         self.errors += _get_qgs105(node)

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -234,6 +234,16 @@ def test_QGS110():
     }
 
 
+def test_QGS111():
+    ret = _results("from qgis import processing")
+    assert ret == set()
+
+    ret = _results("import processing")
+    assert ret == {
+        "1:0 QGS111 Use 'from qgis import processing' instead of 'import processing'"
+    }
+
+
 @pytest.mark.parametrize(
     ("method_name", "imports", "expected_method"),
     [


### PR DESCRIPTION
- add rule QGS111 for proper import of processing module.


### QGS111
Avoid importing processing directly, import it from qgis package

#### Why is this bad?
Although it works sometimes, it is not the recommended way to use the processing module.

#### Example

```python
# Bad
import processing

# Good
from qgis import processing
```


- add test for the new rule
- close #32 