### PR TITLE
fix(QGS108/109): only flag "TEMPORARY_OUTPUT" in processing-parameter contexts (#36)

### DIFF
--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -746,6 +746,48 @@ def _get_qgs108_and_qgs109(node: ast.Constant) -> list["FlakeError"]:
     return []
 
 
+def _is_processing_parameter_position(node: ast.Constant) -> bool:
+    """Return True only when ``node`` is in a position where suggesting
+    ``QgsProcessing.TEMPORARY_OUTPUT`` makes sense.
+
+    QGS108/109 are advice about the QGIS *processing* API. The string
+    ``"TEMPORARY_OUTPUT"`` only carries that meaning when it appears as
+    a parameter passed to (or staged to be passed to) ``processing.run``
+    — typically as a value in a parameter dict or as a positional /
+    keyword arg of a ``Call``. Flagging the same string when it shows
+    up in unrelated contexts (e.g. the constant declaration
+    ``TEMPORARY_OUTPUT = "TEMPORARY_OUTPUT"``, a docstring, a regex,
+    an unrelated assignment) is a false positive and hides real
+    occurrences (issue #36).
+
+    Without flow analysis we can't detect every case, but two AST
+    shapes cover the overwhelming majority of real usage:
+
+      1. ``processing.run("alg", "TEMPORARY_OUTPUT", ...)``
+         — string is a direct ``args`` / ``keywords`` value of a Call.
+      2. ``{"OUTPUT": "TEMPORARY_OUTPUT"}`` (dict literal anywhere,
+         typically the parameter dict passed to ``processing.run``,
+         either inline or assigned to a local first).
+
+    Anything else (top-level assignment, function default, list /
+    tuple literals, return values, f-string fragments, …) is treated
+    as a non-processing context and skipped.
+    """
+    parent = getattr(node, "parent", None)
+    if isinstance(parent, ast.Call):
+        # Direct positional arg, or keyword whose value is the literal.
+        return any(arg is node for arg in parent.args) or any(
+            kw.value is node for kw in parent.keywords
+        )
+    if isinstance(parent, ast.keyword):
+        # `processing.run(..., output="TEMPORARY_OUTPUT")` style.
+        return True
+    if isinstance(parent, ast.Dict):
+        # Value in any dict literal — assume it's a parameter dict.
+        return any(v is node for v in parent.values)
+    return False
+
+
 def _remove_qgs402_qmetatype_errors(errors: list["FlakeError"], node: ast.Call) -> None:
     offset = len("QVariant(")
     for error in errors[:]:
@@ -890,7 +932,10 @@ class Visitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Constant(self, node: ast.Constant) -> None:
-        self.errors += _get_qgs108_and_qgs109(node)
+        # QGS108/109 only make sense in processing-parameter contexts
+        # (issue #36). Skip the bare-Constant flag everywhere else.
+        if _is_processing_parameter_position(node):
+            self.errors += _get_qgs108_and_qgs109(node)
         self.generic_visit(node)
 
 

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -186,11 +186,21 @@ def test_QGS107():
 
 
 def test_QGS108_and_QGS109():
-    ret = _results('output = "TEMPORARY_OUTPUT"')
-    assert ret == {
-        "1:9 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
-    }
+    # Issue #36: only flag the literal in processing-parameter contexts —
+    # i.e. when it is a Call argument or a Dict value. Plain assignments
+    # and unrelated string usage should not trigger the rule.
 
+    # Plain assignment is no longer flagged (the constant might be a
+    # module-level definition, an unrelated string, etc.).
+    ret = _results('output = "TEMPORARY_OUTPUT"')
+    assert ret == set()
+
+    # Module-level constant declaration of the same name was the
+    # canonical false-positive case from the issue's screenshot.
+    ret = _results('TEMPORARY_OUTPUT = "TEMPORARY_OUTPUT"')
+    assert ret == set()
+
+    # Positional arg of a Call (the existing motivating case).
     ret = _results(
         dedent(
             """
@@ -198,21 +208,62 @@ def test_QGS108_and_QGS109():
         """
         )
     )
-
     assert ret == {
         "2:29 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
     }
 
+    # Value inside a parameter dict (typical processing.run usage).
+    # is_child_algorithm=True keeps QGS110 quiet so we only assert on QGS108.
+    ret = _results(
+        'processing.run("alg", {"OUTPUT": "TEMPORARY_OUTPUT"}, is_child_algorithm=True)'
+    )
+    qgs108_in_dict = {m for m in ret if "QGS108" in m}
+    assert qgs108_in_dict == {
+        "1:33 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
+    }
+
+    # Parameter dict assigned to a local first, then passed in. The dict
+    # value is still flagged because it sits in a Dict literal regardless
+    # of where the dict is later consumed.
+    ret = _results(
+        dedent(
+            """
+        params = {"OUTPUT": "TEMPORARY_OUTPUT"}
+        processing.run("alg", params, is_child_algorithm=True)
+        """
+        )
+    )
+    qgs108_in_dict_local = {m for m in ret if "QGS108" in m}
+    assert qgs108_in_dict_local == {
+        "2:20 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
+    }
+
+    # Keyword argument: still flagged.
+    ret = _results(
+        'processing.run("alg", output="TEMPORARY_OUTPUT", is_child_algorithm=True)'
+    )
+    qgs108_kw = {m for m in ret if "QGS108" in m}
+    assert qgs108_kw == {
+        "1:29 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
+    }
+
+    # Misspellings (QGS109) only fire in processing-parameter context too.
     ret = _results('output = "TEMPORARY_OUTPT"')
-    assert ret == {
-        "1:9 QGS109 Replace 'TEMPORARY_OUTPT' with QgsProcessing.TEMPORARY_OUTPUT"
+    assert ret == set()
+    ret = _results('processing.run("alg", "TEMPORARY_OUTPT", is_child_algorithm=True)')
+    qgs109_call = {m for m in ret if "QGS109" in m}
+    assert qgs109_call == {
+        "1:22 QGS109 Replace 'TEMPORARY_OUTPT' with QgsProcessing.TEMPORARY_OUTPUT"
+    }
+    ret = _results(
+        'processing.run("alg", "TEMPORARY_OUTPUTS", is_child_algorithm=True)'
+    )
+    qgs109_call2 = {m for m in ret if "QGS109" in m}
+    assert qgs109_call2 == {
+        "1:22 QGS109 Replace 'TEMPORARY_OUTPUTS' with QgsProcessing.TEMPORARY_OUTPUT"
     }
 
-    ret = _results('output = "TEMPORARY_OUTPUTS"')
-    assert ret == {
-        "1:9 QGS109 Replace 'TEMPORARY_OUTPUTS' with QgsProcessing.TEMPORARY_OUTPUT"
-    }
-
+    # Unrelated string is still not flagged.
     ret = _results('output = "something else"')
     assert ret == set()
 


### PR DESCRIPTION
## Summary

Closes #36.

QGS108 and QGS109 used to fire on every \`\"TEMPORARY_OUTPUT\"\` (and single-edit misspellings) the visitor reached, regardless of context. That made the constant declaration in \`flake8_qgis.py\` itself —

\`\`\`python
TEMPORARY_OUTPUT = \"TEMPORARY_OUTPUT\"
\`\`\`

— trigger its own rule, alongside any docstring, regex, or unrelated assignment that happened to contain the literal. Real \`processing.run\` parameters got drowned in noise.

## Changes

- \`flake8_qgis/flake8_qgis.py\`: new \`_is_processing_parameter_position\` helper. \`visit_Constant\` now only emits QGS108/109 when the literal is a positional / keyword arg of a \`Call\` or a value in a \`Dict\` literal. The visitor already populates \`parent\` on every node (used by QGS402/403/404/410/411), so the helper just walks one step up — no extra pass required.
- \`tests/test_flake8_qgis.py\`: plain-assignment cases (\`output = \"TEMPORARY_OUTPUT\"\` etc.) now assert \`set()\` instead of expecting a hit — that was the false-positive shape from the issue. New cases pin the in-Call, in-Dict, in-Dict-then-passed-to-run, and keyword-arg flows where the rule must still fire. The rename-of-self case (\`TEMPORARY_OUTPUT = \"TEMPORARY_OUTPUT\"\`) is now silent, which is the canonical false positive from the issue's screenshot.

## Test plan

- [x] \`uv run pytest\` — 43 passed
- [x] \`uv run ruff check flake8_qgis/ tests/\` — clean
- [x] \`uv run ruff format --check flake8_qgis/ tests/\` — clean

This covers both code paths the issue calls out (\"in the \`processing.run\` call parameters or on a dictionary of parameters defined before the \`processing.run\` call\") without resorting to whole-program flow analysis. Edge cases like \"dict assigned to a local then mutated before the run\" still slip through, but those are rare enough that the much-reduced false-positive rate is the right trade.