### PR TITLE
Fix QGS110 false positive outside processing algorithms

### DIFF
--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -451,6 +451,33 @@ def _get_qgs107_attribute(node: ast.Attribute) -> list["FlakeError"]:
     return []
 
 
+def _get_qualified_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        value_name = _get_qualified_name(node.value)
+        if value_name is not None:
+            return f"{value_name}.{node.attr}"
+    return None
+
+
+def _is_qgs_processing_algorithm_class(node: ast.ClassDef) -> bool:
+    return any(
+        _get_qualified_name(base)
+        in {"QgsProcessingAlgorithm", "qgis.core.QgsProcessingAlgorithm"}
+        for base in node.bases
+    )
+
+
+def _is_inside_qgs_processing_algorithm_class(node: ast.AST) -> bool:
+    parent = getattr(node, "parent", None)
+    while parent is not None:
+        if isinstance(parent, ast.ClassDef):
+            return _is_qgs_processing_algorithm_class(parent)
+        parent = getattr(parent, "parent", None)
+    return False
+
+
 def _get_qgs110(node: Call) -> list["FlakeError"]:
     assert isinstance(node.func, ast.Attribute)
     if not (
@@ -458,6 +485,9 @@ def _get_qgs110(node: Call) -> list["FlakeError"]:
         and node.func.value.id == "processing"
         and node.func.attr == "run"
     ):
+        return []
+
+    if not _is_inside_qgs_processing_algorithm_class(node):
         return []
 
     is_child_keyword = None

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -222,16 +222,60 @@ def test_QGS110():
     assert ret == set()
 
     ret = _results("processing.run('native:buffer', {})")
+    assert ret == set()
+
+    ret = _results(
+        dedent(
+            """
+            def helper():
+                processing.run('native:buffer', {})
+            """
+        )
+    )
+    assert ret == set()
+
+    ret = _results(
+        dedent(
+            """
+            class MyAlgorithm(QgsProcessingAlgorithm):
+                def processAlgorithm(self):
+                    processing.run('native:buffer', {})
+            """
+        )
+    )
     assert ret == {
-        "1:0 QGS110 Use is_child_algorithm=True when running other algorithms in the "
+        "4:8 QGS110 Use is_child_algorithm=True when running other algorithms in the "
         "plugin"
     }
 
-    ret = _results("processing.run('native:buffer', {}, is_child_algorithm=False)")
+    ret = _results(
+        dedent(
+            """
+            class MyAlgorithm(qgis.core.QgsProcessingAlgorithm):
+                def processAlgorithm(self):
+                    processing.run('native:buffer', {}, is_child_algorithm=False)
+            """
+        )
+    )
     assert ret == {
-        "1:0 QGS110 Use is_child_algorithm=True when running other algorithms in the "
+        "4:8 QGS110 Use is_child_algorithm=True when running other algorithms in the "
         "plugin"
     }
+
+    ret = _results(
+        dedent(
+            """
+            class MyAlgorithm(QgsProcessingAlgorithm):
+                def processAlgorithm(self):
+                    processing.run(
+                        'native:buffer',
+                        {},
+                        is_child_algorithm=True,
+                    )
+            """
+        )
+    )
+    assert ret == set()
 
 
 def test_QGS111():


### PR DESCRIPTION
## Summary

Fixes `QGS110` false positives for `processing.run(...)` calls outside processing algorithm classes.

## Related issues

Fixes #37

## How this was tested

- `uv run pytest tests/test_flake8_qgis.py -k QGS110`
- `uv run pytest tests`
- `uv run pre-commit run --all-files`

## Notes

`QGS110` is intended for calls made from processing algorithm classes. This keeps the existing report for `QgsProcessingAlgorithm` subclasses while allowing ordinary plugin/helper code to call `processing.run(...)` without requiring `is_child_algorithm=True`.

AI assistance disclosure: I used Codex to inspect the rule/test structure and draft the regression test/fix, then reviewed the final diff and ran the listed commands locally.