### PR TITLE
Add test for other method names in QGS110

### DIFF
--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -252,6 +252,20 @@ def test_QGS110():
         dedent(
             """
             class MyAlgorithm(qgis.core.QgsProcessingAlgorithm):
+                def _other_method(self):
+                    processing.run()
+            """
+        )
+    )
+    assert ret == {
+        "4:8 QGS110 Use is_child_algorithm=True when running other algorithms in the "
+        "plugin"
+    }
+
+    ret = _results(
+        dedent(
+            """
+            class MyAlgorithm(qgis.core.QgsProcessingAlgorithm):
                 def processAlgorithm(self):
                     processing.run('native:buffer', {}, is_child_algorithm=False)
             """


### PR DESCRIPTION
<!--
Thank you for contributing to an OSGeo Suomi project!

Please write this description yourself. Translation or copy-editing tools are
fine, pasting LLM output as your design rationale is not. See CONTRIBUTING.md.
-->

## Summary

add a test for other names of methods othe than only `processAlgorithm` since sometimes helper methods are used inside the algorithm class but not strictly inside `processAlgorithm` 

## Related issues

<!-- e.g. Fixes #123, Refs #456 -->

## How this was tested

`pytest`

all 43 tests pass

## Contributor checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/osgeosuomi/.github/blob/main/CONTRIBUTING.md).
- [x] **I have reviewed and understand every change in this pull request, and I take responsibility for it as the author.** This applies whether the changes were written by hand or with the assistance of AI tools.
- [x] If AI tools were used to generate a substantial part of this contribution, I have disclosed it in the PR description above or via an `Assisted-by:` commit trailer.
- [x] My contribution is licensed under the same license as this repository, and I have the right to submit it.
- [x] I have run the project's tests locally where applicable.
