### PR TITLE
Scope QGS108 and QGS109 to strings inside `processing.run(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Undeleased
 
+## New Features
+
+* [#33](https://github.com/osgeosuomi/flake8-qgis/pull/33) Add QGS111 rule to
+  require importing `processing` from `qgis` instead of as a top-level module.
+* [#31](https://github.com/osgeosuomi/flake8-qgis/pull/31) Extend QGS403 with
+  additional deprecated/renamed Qt enums.
+
+## Fixes
+
+* [#42](https://github.com/osgeosuomi/flake8-qgis/pull/42) Scope QGS108 and QGS109 to strings inside `processing.run(...)` calls to avoid
+  false positives in unrelated code.
+* [#40](https://github.com/osgeosuomi/flake8-qgis/pull/40),
+  [#41](https://github.com/osgeosuomi/flake8-qgis/pull/41) Scope QGS110 to
+  methods of classes that inherit from `QgsProcessingAlgorithm` to avoid false
+  positives in unrelated code.
+* [#31](https://github.com/osgeosuomi/flake8-qgis/pull/31) Fix QGS403 to not
+  flag enums that already use the correct Qt6 form.
+
+## Maintenance tasks
+
+* [#39](https://github.com/osgeosuomi/flake8-qgis/pull/39) Add a pull request
+  template and links to contributor guidelines.
+
 
 # Version 2.0.1 (18-03-2026)
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Just call `flake8 .` in your package or `flake your.py`.
  [QGS105](#QGS105) | Avoid passing QgisInterface as an argument
  [QGS106](#QGS106) | Avoid importing gdal directly, import it from osgeo package
  [QGS107](#QGS107) | Use 'exec' instead of 'exec_'
- [QGS108](#QGS108) | Use QgsProcessing.TEMPORARY_OUTPUT instead of "TEMPORARY_OUTPUT"
- [QGS109](#QGS109) | Use QgsProcessing.TEMPORARY_OUTPUT instead of misspelled "TEMPORARY_OUTPUT"
+ [QGS108](#QGS108) | Use QgsProcessing.TEMPORARY_OUTPUT instead of "TEMPORARY_OUTPUT" in `processing.run`
+ [QGS109](#QGS109) | Use QgsProcessing.TEMPORARY_OUTPUT instead of misspelled "TEMPORARY_OUTPUT" in `processing.run`
  [QGS110](#QGS110) | Use is_child_algorithm=True when running other algorithms in the plugin
  [QGS111](#QGS111) | Avoid importing processing directly, import it from qgis package
  [QGS201](#QGS201) | Check return values from a probable PyQgs method call
@@ -233,6 +233,8 @@ window.exec()
 
 Use QgsProcessing.TEMPORARY_OUTPUT instead of "TEMPORARY_OUTPUT"
 
+This rule is only active when the string appears inside a `processing.run(...)` call.
+
 #### Why is this bad?
 
 It is a good practice to use the constant that PyQGIS API provides.
@@ -241,18 +243,24 @@ It is a good practice to use the constant that PyQGIS API provides.
 
 ```python
 # Bad
-output = "TEMPORARY_OUTPUT"
+processing.run("native:buffer", {"INPUT": layer, "OUTPUT": "TEMPORARY_OUTPUT"})
 
 # Good
 from qgis.core import QgsProcessing
 
-output = QgsProcessing.TEMPORARY_OUTPUT
+processing.run(
+    "native:buffer",
+    {"INPUT": layer, "OUTPUT": QgsProcessing.TEMPORARY_OUTPUT},
+)
 ```
 
 ### QGS109
 
 Use QgsProcessing.TEMPORARY_OUTPUT instead of misspelled "TEMPORARY_OUTPUT"
 
+This rule is only active when the misspelled string appears inside a
+`processing.run(...)` call.
+
 #### Why is this bad?
 
 It is a good practice to use the constant that PyQGIS API provides.
@@ -261,12 +269,15 @@ It is a good practice to use the constant that PyQGIS API provides.
 
 ```python
 # Bad
-output = "TEMPRARY_OUTPUT"
+processing.run("native:buffer", {"INPUT": layer, "OUTPUT": "TEMPRARY_OUTPUT"})
 
 # Good
 from qgis.core import QgsProcessing
 
-output = QgsProcessing.TEMPORARY_OUTPUT
+processing.run(
+    "native:buffer",
+    {"INPUT": layer, "OUTPUT": QgsProcessing.TEMPORARY_OUTPUT},
+)
 ```
 
 ### QGS110

--- a/flake8_qgis/flake8_qgis.py
+++ b/flake8_qgis/flake8_qgis.py
@@ -478,6 +478,29 @@ def _is_inside_qgs_processing_algorithm_class(node: ast.AST) -> bool:
     return False
 
 
+def _is_processing_run_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "processing"
+        and node.func.attr == "run"
+    )
+
+
+def _is_inside_processing_run_call(node: ast.AST) -> bool:
+    parent = getattr(node, "parent", None)
+    while parent is not None:
+        if _is_processing_run_call(parent):
+            return True
+        if isinstance(
+            parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)
+        ):
+            return False
+        parent = getattr(parent, "parent", None)
+    return False
+
+
 def _get_qgs110(node: Call) -> list["FlakeError"]:
     assert isinstance(node.func, ast.Attribute)
     if not (
@@ -763,16 +786,21 @@ def _get_qgs412(node: Call) -> list["FlakeError"]:
 
 
 def _get_qgs108_and_qgs109(node: ast.Constant) -> list["FlakeError"]:
-    if isinstance(node.value, str):
-        if node.value == TEMPORARY_OUTPUT:
-            return [(node.lineno, node.col_offset, QGS108)]
+    if not isinstance(node.value, str):
+        return []
 
-        if (
-            node.value.startswith("TEMP")
-            and "_" in node.value
-            and _is_within_one_edit(node.value, TEMPORARY_OUTPUT)
-        ):
-            return [(node.lineno, node.col_offset, QGS109.format(old=node.value))]
+    if not _is_inside_processing_run_call(node):
+        return []
+
+    if node.value == TEMPORARY_OUTPUT:
+        return [(node.lineno, node.col_offset, QGS108)]
+
+    if (
+        node.value.startswith("TEMP")
+        and "_" in node.value
+        and _is_within_one_edit(node.value, TEMPORARY_OUTPUT)
+    ):
+        return [(node.lineno, node.col_offset, QGS109.format(old=node.value))]
     return []
 
 

--- a/tests/test_flake8_qgis.py
+++ b/tests/test_flake8_qgis.py
@@ -186,11 +186,6 @@ def test_QGS107():
 
 
 def test_QGS108_and_QGS109():
-    ret = _results('output = "TEMPORARY_OUTPUT"')
-    assert ret == {
-        "1:9 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
-    }
-
     ret = _results(
         dedent(
             """
@@ -203,18 +198,64 @@ def test_QGS108_and_QGS109():
         "2:29 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
     }
 
-    ret = _results('output = "TEMPORARY_OUTPT"')
+    ret = _results(
+        dedent(
+            """
+            processing.run(
+                "native:buffer",
+                {"INPUT": layer, "OUTPUT": "TEMPORARY_OUTPUT"},
+                is_child_algorithm=True,
+            )
+            """
+        )
+    )
     assert ret == {
-        "1:9 QGS109 Replace 'TEMPORARY_OUTPT' with QgsProcessing.TEMPORARY_OUTPUT"
+        "4:31 QGS108 Replace 'TEMPORARY_OUTPUT' with QgsProcessing.TEMPORARY_OUTPUT"
     }
 
-    ret = _results('output = "TEMPORARY_OUTPUTS"')
+    ret = _results(
+        dedent(
+            """
+            processing.run(
+                "native:buffer",
+                {"INPUT": layer, "OUTPUT": "TEMPORARY_OUTPT"},
+                is_child_algorithm=True,
+            )
+            """
+        )
+    )
     assert ret == {
-        "1:9 QGS109 Replace 'TEMPORARY_OUTPUTS' with QgsProcessing.TEMPORARY_OUTPUT"
+        "4:31 QGS109 Replace 'TEMPORARY_OUTPT' with QgsProcessing.TEMPORARY_OUTPUT"
     }
 
-    ret = _results('output = "something else"')
-    assert ret == set()
+    ret = _results(
+        dedent(
+            """
+            processing.run(
+                "native:buffer",
+                {"INPUT": layer, "OUTPUT": "TEMPORARY_OUTPUTS"},
+                is_child_algorithm=True,
+            )
+            """
+        )
+    )
+    assert ret == {
+        "4:31 QGS109 Replace 'TEMPORARY_OUTPUTS' with QgsProcessing.TEMPORARY_OUTPUT"
+    }
+
+    # Outside processing.run, the string should not trigger any error.
+    assert _results('output = "TEMPORARY_OUTPUT"') == set()
+    assert _results('output = "TEMPORARY_OUTPUTS"') == set()
+    assert (
+        _results(
+            dedent(
+                """
+                some_other.run("native:buffer", {"OUTPUT": "TEMPORARY_OUTPUT"})
+                """
+            )
+        )
+        == set()
+    )
 
 
 def test_QGS110():


### PR DESCRIPTION
<!--
Thank you for contributing to an OSGeo Suomi project!

Please write this description yourself. Translation or copy-editing tools are
fine, pasting LLM output as your design rationale is not. See CONTRIBUTING.md.
-->

## Summary

This PR makes QGS108 and QGS109 to trigger only when used within `processing.run` calls.

Claude was used to generate code and tests. I  reviewed and adjusted the output.

## Related issues

Fixes #36.

## How this was tested

Tested with unit tests.

## Contributor checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/osgeosuomi/.github/blob/main/CONTRIBUTING.md).
- [x] **I have reviewed and understand every change in this pull request, and I take responsibility for it as the author.** This applies whether the changes were written by hand or with the assistance of AI tools.
- [x] If AI tools were used to generate a substantial part of this contribution, I have disclosed it in the PR description above or via an `Assisted-by:` commit trailer.
- [x] My contribution is licensed under the same license as this repository, and I have the right to submit it.
- [x] I have run the project's tests locally where applicable.
